### PR TITLE
Fix for could not initialize class org.xerial.snappy.Snappy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache \
     'findutils=~4.6' \
     'ncurses=~6.1' \
     'g++=~8.3' \
-    'libc6-compat' \
+    'libc6-compat=~1.1' \
     && ln -s /lib64/ld-linux-x86-64.so.2 /lib/ld-linux-x86-64.so.2
 
 # https://github.com/hadolint/hadolint/wiki/DL4006

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN apk add --no-cache \
     'procps=~3.3' \
     'findutils=~4.6' \
     'ncurses=~6.1' \
-    'g++=~8.3'
+    'g++=~8.3' \
+    'libc6-compat' \
+    && ln -s /lib64/ld-linux-x86-64.so.2 /lib/ld-linux-x86-64.so.2
 
 # https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Fixed the issue outlined in the bigdata-docker-compose issue #2 .
Had to add symlink for compatibility and install libc6-compat to fix the issue.